### PR TITLE
Pagina Cuenta de Ahorro , Corrección de estilos

### DIFF
--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -10,6 +10,7 @@ import index from './pages/index.vue';
 import home from './pages/home.vue';
 import registro from './pages/registro.vue';
 import logintest from './pages/logintest.vue';
+import cuentadeahorro from './pages/cuentadeahorro.vue';
 import { onMounted } from 'vue';
 import API from '@/API.js';
 

--- a/src/frontend/src/components/Register/RegisterPage.vue
+++ b/src/frontend/src/components/Register/RegisterPage.vue
@@ -163,7 +163,7 @@ export default {
 };
 </script>
 
-<style setup>
+<style scoped>
 h1 {
   font-size: 50px;
   display: flex;

--- a/src/frontend/src/components/index/indexCuentadeahorro.vue
+++ b/src/frontend/src/components/index/indexCuentadeahorro.vue
@@ -1,0 +1,96 @@
+<template>
+    <div class="pagina">
+      <v-app>
+        <h1 class="titulo">Cuenta de Ahorro</h1>
+        <v-container class="container">
+          <v-row>
+            <v-col>
+              <v-card class="square-card">
+                <div style="display: flex; flex-direction: column;">
+  
+                  <div style="display: flex">
+                    <img src="https://i.ytimg.com/vi/_WqiodYeykI/maxresdefault.jpg" alt="Imagen de fondo"
+                      width="600" height="510" />
+                    <h2>
+                      ¡Hola! ¿Te gustaría abrir una cuenta de Ahorros? Es súper fácil: solo necesitas hacer un depósito inicial
+                      de $100.000 pesos. Una vez creada, puedes hacer depósitos sin límite , ¡sí, sin límite! Pero ten en
+                      cuenta que los retiros solo pueden realizarse si el saldo está por encima de $50.000 pesos. Si un retiro
+                      baja el saldo por debajo de ese monto, la cuenta se vuelve inactiva hasta que superen los $100.000 pesos
+                      nuevamente. No te preocupes, ¡no podrás retirar más de lo que tienes!
+                    </h2>
+                  </div>
+                  <div class="abajo">
+                    <h3>Ingrese el depósito inicial</h3>
+  
+                    
+  
+                    <v-text-field
+                      label="Depósito inicial"
+                      v-model="depositoInicial"
+                      :rules="[rules.required, rules.numeric]"
+                    ></v-text-field>
+                    
+                    <h3>Escoja su sucursal</h3>
+                    <v-select label="Sucursal" :items="[
+                          'Sucursal Talca',
+                          'Sucursal Paris',
+                          'Sucursal Londres'
+                      ]" v-model="sucursalSeleccionada"></v-select>
+  
+                    <v-btn class="botonContratar" :disabled="!sucursalSeleccionada || !depositoInicial">Contratar</v-btn>
+                  </div>
+                </div>
+              </v-card>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-app>
+    </div>
+  </template>
+  
+  <script>
+  export default {
+    data() {
+      return {
+        sucursalSeleccionada: null,
+        depositoInicial: null,
+        rules: {
+          required: (value) => !!value || 'Este campo es requerido',
+          numeric: (value) => /^\d+(\.\d+)?$/.test(value) || 'Ingrese solo números',
+        },
+      };
+    },
+  };
+  </script>
+<style scoped>
+.pagina {
+    width: 100%;
+}
+
+.titulo {
+    text-align: center;
+}
+
+.square-card {
+    width: 1000px;
+    justify-content: space-between;
+    padding: 1rem;
+    text-align: center;
+}
+
+.abajo {
+  display: block;
+  text-align: left;
+  align-items: left; /* Alinea los elementos en el centro horizontalmente */
+}
+
+.botonContratar {
+    margin-left: 1rem;
+    margin-right: 2rem;
+    margin-top: 10px;
+}
+
+h2 {
+    padding: 1rem;
+}
+</style>

--- a/src/frontend/src/components/index/indexRegistro.vue
+++ b/src/frontend/src/components/index/indexRegistro.vue
@@ -154,7 +154,7 @@ export default {
 };
 </script>
   
-<style setup>
+<style scoped>
 .registro-container {
   background-color: #d9d9d9;
   display: flex;

--- a/src/frontend/src/pages/cuentadeahorro.vue
+++ b/src/frontend/src/pages/cuentadeahorro.vue
@@ -1,0 +1,10 @@
+<script setup>
+    import cuentadeahorro from '../components/index/indexCuentadeahorro.vue'
+</script>
+
+<template>
+    <cuentadeahorro></cuentadeahorro>
+</template>
+
+<style>
+</style>

--- a/src/frontend/src/router.js
+++ b/src/frontend/src/router.js
@@ -23,6 +23,11 @@ const routes = [
     name: 'logintest',
     component: () => import('./pages/logintest.vue'),
   },
+  {
+    path: '/cuentadeahorro',
+    name: 'cuentadeahorro',
+    component: () => import('./pages/cuentadeahorro.vue'),
+  },
 ];
 
 const router = createRouter({


### PR DESCRIPTION
Se crea la página cuenta de ahorro, similar a la de cuenta corriente para que sea mas fácil implementar la futura mejora visual. Para visualizarla es necesario ir a
/cuentadeahorro .
Se corrigen los estilos escribiendolos como "scoped" para que no se puedan llamar en otros componentes.